### PR TITLE
Add LineReaderF and Run interpreter

### DIFF
--- a/src/LineReader/Run.purs
+++ b/src/LineReader/Run.purs
@@ -37,7 +37,7 @@ import Node.ReadLine.Aff (Interface, InterfaceOptions, READLINE, prompt)
 import Node.ReadLine.Aff (READLINE, InterfaceOptions, createConsoleInterface, createInterface, output, completer, terminal, historySize, Completer, noCompletion) as RLExports
 import Node.ReadLine.Aff (question) as A
 import Node.Stream (Readable)
-import Run (AFF, FProxy, Run, SProxy(SProxy), interpret, interpretRec, lift, liftAff, on, runBaseAff, send)
+import Run (AFF, FProxy, Run, SProxy(SProxy), interpretRec, lift, liftAff, on, runBaseAff, send)
 import Run.Reader (READER, ask, runReader)
 
 data LineReaderF r
@@ -69,9 +69,9 @@ question q = lift _linereader (Question q id)
 
 runLineReader
   :: forall r eff
-   . Run (linereader :: LINEREADER | r)
+   . Run (linereader :: LINEREADER, reader :: READER Interface, aff :: AFF (readline :: READLINE, console :: CONSOLE, exception :: EXCEPTION | eff) | r)
   ~> Run (reader :: READER Interface, aff :: AFF (readline :: READLINE, console :: CONSOLE, exception :: EXCEPTION | eff) | r)
-runLineReader = interpret (on _linereader handleLineReader send)
+runLineReader = interpretRec (on _linereader handleLineReader send)
 
 -- | Run a Line Reader computation from the Run Monad into the Aff Monad
 lineReaderToAff


### PR DESCRIPTION
Failing with Error

```
Run.purs|74 col 28 error| Could not match type
|| 
||     ( aff :: FProxy
||                (Aff
||                   ( readline :: READLINE
||                   , console :: CONSOLE
||                   , exception :: EXCEPTION
||                   | eff6
||                   )
||                )
||     , reader :: FProxy (Reader Interface)
||     , linereader :: FProxy LineReaderF
||     | r7
||     )
|| 
||   with type
|| 
||     ( linereader :: FProxy LineReaderF
||     | r7
||     )
|| 
|| 
|| while solving type class constraint
|| 
||   Prim.RowCons "linereader"
||                (FProxy LineReaderF)
||                ( reader :: FProxy (Reader Interface)
||                , aff :: FProxy
||                           (Aff
||                              ( readline :: READLINE
||                              , console :: CONSOLE
||                              , exception :: EXCEPTION
||                              | eff6
||                              )
||                           )
||                | r7
||                )
||                ( linereader :: FProxy LineReaderF
||                | r7
||                )
|| 
|| while applying a function on
||   of type RowCons t0 (FProxy t1) t2 t3 => IsSymbol t0 => SProxy t0 -> (t1 t4 -> t5) -> (VariantF t2 t4 -> t5) -> VariantF t3 t4 -> t5
||   to argument _linereader
|| while inferring the type of on _linereader
|| in value declaration runLineReader
|| 
|| where eff6 is a rigid type variable
||         bound at line 74, column 17 - line 74, column 65
||       r7 is a rigid type variable
||         bound at line 74, column 17 - line 74, column 65
||       t3 is an unknown type
||       t2 is an unknown type
||       t5 is an unknown type
||       t4 is an unknown type
||       t1 is an unknown type
||       t0 is an unknown type
```